### PR TITLE
Issue forms ask for the breadcrumb file the logs cannot replace

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question about how something works
+    url: https://github.com/characterecho-sean/edvr-unofficial-patch/blob/main/README.md
+    about: The README covers what each fix does, what it reads, and every setting in edvr.ini. Worth a look before opening an issue.

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -1,0 +1,122 @@
+name: Crash, or the game will not start
+description: The game closes by itself, freezes, or never reaches the menu.
+title: "[crash] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Sorry this is happening. First, so you can play in the meantime: **delete `d3d11.dll`** from the game folder and the game returns to normal immediately. If you installed the transition flash fix as well, also delete the `openvr_api.dll` you copied in and rename `openvr_api_orig.dll` back.
+
+        Then please fill this in. Every field below has cost me a session of guessing at some point — the ones marked required are the ones I cannot work without.
+
+        **Where the files live.** `edvr_breadcrumbs.txt` and `edvr_FATAL.txt` sit next to `EliteDangerous64.exe`. The logs are in the `edvr_logs\` folder beside it. If you cannot find the game folder, open the log you do have and read its third line — it prints the folder it loaded from.
+
+  - type: textarea
+    id: breadcrumbs
+    attributes:
+      label: edvr_breadcrumbs.txt
+      description: |
+        **This is the most important file in a crash report and almost nobody sends it.** The log is written through a buffer, so a crash eats the last few lines — the breadcrumb file is written one line at a time with no buffering, specifically so it survives. It is what tells me whether EDVR got its hooks installed and whether the game exited normally or was killed.
+
+        It sits next to `EliteDangerous64.exe`. Drag it in, or paste the whole thing. It is short.
+      placeholder: Drag edvr_breadcrumbs.txt here, or paste its contents.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: The logs from the crashed session
+      description: |
+        Everything in `edvr_logs\`, or at least **both files from the run that crashed** — `edvr_gfx_*.log` and `edvr_vr_*.log` with matching timestamps. One without the other only tells half the story: the two halves of EDVR are separate DLLs and each one logs things the other cannot see.
+
+        They are plain text. The module directory line contains your game folder path, and if EDVR read your Elite key bindings the log names your `.binds` file, which may include your commander name — glance over it if that matters to you.
+      placeholder: Drag the log files here, or paste them.
+    validations:
+      required: true
+
+  - type: input
+    id: build
+    attributes:
+      label: Which EDVR build
+      description: The second line of any EDVR log. Copy it whole — the linked timestamp is what actually identifies the build.
+      placeholder: "build 6A820743 -- this DLL was linked 2026-08-16 18:53:55 UTC"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happens
+    attributes:
+      label: What happens, and when
+      description: |
+        How far does it get — no window at all, the launcher, the main menu, in flight, on foot? Does it happen every time or now and then? If now and then, roughly how long into a session?
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-mods
+    attributes:
+      label: Other mods
+      description: |
+        **Name the DLL each one is installed as.** EDHM, ReShade and 3Dmigoto all install as a `d3d11.dll` or a `dxgi.dll`, and two of them reaching for the same thing is a recurring cause of exactly this. Version numbers help.
+
+        Write "none" if there are none — that is a useful answer too.
+      placeholder: |
+        EDHM v22.01, renamed to d3d11_edhm.dll
+        ReShade 6.8.0, installed as dxgi.dll
+    validations:
+      required: true
+
+  - type: textarea
+    id: ini
+    attributes:
+      label: Anything you changed in edvr.ini
+      description: |
+        Just the lines you changed from what shipped. These are the ones that matter most, if you have touched any of them: `vscreen_res_width` / `vscreen_res_height`, `panel_distance`, `transition_flash`, `head_offset_gate`, `camera_index_track`, and `advanced.real_dll`.
+
+        Write "nothing" if it is the file as shipped.
+    validations:
+      required: true
+
+  - type: input
+    id: game-folder
+    attributes:
+      label: Your game folder
+      description: |
+        The third line of the `edvr_gfx` log prints it. Steam, the Frontier launcher and Epic all put the game somewhere different, and knowing which layout you have is genuinely useful to me.
+      placeholder: "F:\\Program Files (x86)\\Frontier\\EDLaunch\\Products\\elite-dangerous-odyssey-64"
+    validations:
+      required: true
+
+  - type: input
+    id: headset
+    attributes:
+      label: Headset and runtime
+      description: Which headset, and what it runs through — SteamVR, Oculus, Oasis, WMR, Virtual Desktop.
+      placeholder: HP Reverb G2 via the Oasis driver
+    validations:
+      required: true
+
+  - type: input
+    id: faulting-module
+    attributes:
+      label: Faulting module (optional, but it often settles the whole question)
+      description: |
+        Windows **Event Viewer** → Windows Logs → Application. Find the *Application Error* entry for `EliteDangerous64.exe` and copy the **faulting module name** line. That one field usually says outright whether this is EDVR, another mod, the driver, or the game.
+      placeholder: "Faulting module name: d3d11.dll, version ..."
+
+  - type: textarea
+    id: fatal
+    attributes:
+      label: edvr_FATAL.txt (optional — only if one exists)
+      description: If EDVR caught something fatal it writes this file next to `EliteDangerous64.exe`. Most crashes do not produce one; its absence is not a problem.
+
+  - type: textarea
+    id: system
+    attributes:
+      label: System (optional)
+      placeholder: |
+        Windows 11, latest update
+        RTX 5080
+        Intel Core i7 9700K

--- a/.github/ISSUE_TEMPLATE/fix-not-working.yml
+++ b/.github/ISSUE_TEMPLATE/fix-not-working.yml
@@ -1,0 +1,98 @@
+name: A fix is not doing what it should
+description: The game runs, but one of the fixes does nothing, or does the wrong thing.
+title: "[fix] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The logs answer most of these on their own — every fix says in the log whether it armed, what it matched, and why it declined. So the two log files are worth more here than a description of what you saw.
+
+        They live in `edvr_logs\` next to `EliteDangerous64.exe`. If you cannot find the game folder, open any log and read its third line — it prints the folder it loaded from.
+
+  - type: dropdown
+    id: which-fix
+    attributes:
+      label: Which fix
+      options:
+        - Explorer Cam (stereo depth on foot)
+        - Transition flash (the flash when jumping, dropping, or closing the map)
+        - Eye brightness / exposure
+        - The on-foot screen's resolution
+        - The on-foot screen's distance
+        - The black void around the on-foot screen
+        - Something else, or I am not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Both logs, from the same session
+      description: |
+        **`edvr_gfx_*.log` and `edvr_vr_*.log` with matching timestamps, from one run where the problem happened.** This is the thing I most often have to ask for a second time.
+
+        The two halves of EDVR are separate DLLs in different folders and neither can see what the other does. Explorer Cam in particular is decided in the gfx half and applied in the vr half — sent one of them, I can see that it did not happen but not why. If the vr log is missing entirely, say so, because that is itself an answer.
+
+        Please send the whole files rather than the lines that look relevant. What explains a fix declining is usually somewhere you would not think to look.
+
+        They are plain text. The module directory line contains your game folder path, and if EDVR read your Elite key bindings the log names your `.binds` file, which may include your commander name — glance over it if that matters to you.
+      placeholder: Drag both log files here, or paste them.
+    validations:
+      required: true
+
+  - type: input
+    id: build
+    attributes:
+      label: Which EDVR build
+      description: The second line of any EDVR log. Copy it whole — the linked timestamp is what actually identifies the build.
+      placeholder: "build 6A820743 -- this DLL was linked 2026-08-16 18:53:55 UTC"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected, and what happened instead
+      description: |
+        If it is Explorer Cam, say which camera preset you were on and how you got into the camera — the preset the offset is for is a setting, and the wrong one is the most common reason nothing happens.
+
+        If it is the transition flash and you saw one get through: press **Pause** right after it and then quit. That writes the last ten seconds of viewpoint history into the log, which is the only thing that separates "the bad frame was spotted and let through" from "it was never spotted at all". Those are different problems with different fixes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ini
+    attributes:
+      label: Anything you changed in edvr.ini
+      description: Just the lines you changed from what shipped. Write "nothing" if it is the file as shipped.
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-mods
+    attributes:
+      label: Other mods
+      description: |
+        Name the DLL each one is installed as — EDHM, ReShade and 3Dmigoto all install as a `d3d11.dll` or a `dxgi.dll`. Write "none" if there are none.
+      placeholder: |
+        EDHM v22.01, renamed to d3d11_edhm.dll
+        ReShade 6.8.0, installed as dxgi.dll
+    validations:
+      required: true
+
+  - type: input
+    id: headset
+    attributes:
+      label: Headset and runtime
+      description: Which headset, and what it runs through — SteamVR, Oculus, Oasis, WMR, Virtual Desktop.
+      placeholder: HP Reverb G2 via the Oasis driver
+    validations:
+      required: true
+
+  - type: input
+    id: game-folder
+    attributes:
+      label: Your game folder (optional)
+      description: The third line of the `edvr_gfx` log prints it. Steam, the Frontier launcher and Epic all put the game somewhere different.
+      placeholder: "C:\\SteamLibrary\\steamapps\\common\\Elite Dangerous\\Products\\elite-dangerous-odyssey-64"


### PR DESCRIPTION
Three crash reports in, the same evidence has gone missing every time. edvr_breadcrumbs.txt is the file that survives a crash -- the log is written through a buffer and loses its tail -- and nobody sends it, because from the outside it looks like a duplicate of the log. The crash form asks for it first, requires it, and says why.

The other recurring gap is half a session: one reporter sent only the vr log, another only the gfx log. Neither half can see what the other does, so a fix that was decided in d3d11.dll and applied in openvr_api.dll reads as "it did not happen" with no way to tell where it stopped. Both forms ask for both files from one run, and the fix form says outright that a missing vr log is itself an answer.

Two forms rather than one, because the useful evidence differs. A crash wants breadcrumbs and the Event Viewer faulting module; a fix misbehaving wants the logs in full and little else. Merging them would ask every reporter for things that do not apply to them.

The rest of the fields each cost a session at some point: the build line (dating installs from breadcrumb strings, three times over), the DLL name each other mod is installed under (EDHM, ReShade and 3Dmigoto have appeared in every crash so far), and the game folder -- worth collecting while the documented path still matches no reporter's install.

Both forms soften the "nothing personal" claim the shipped README still makes: since bindings adoption the log names the .binds file, which can carry a commander name.