### PR TITLE
guard: an absorbed fault says so first, because #13 read it as a crash

### DIFF
--- a/src/common/guard.cpp
+++ b/src/common/guard.cpp
@@ -56,7 +56,7 @@ int guardFilter(unsigned long code, const char* site) {
             // lines however bad it gets, and makes runaway visible AS runaway.
             if ((g_sites[i].count & (g_sites[i].count - 1)) == 0) {
                 Log::get().note("FAULT TOTAL site=%s: %llu absorbed so far this "
-                                "session.", key,
+                                "session -- still caught, still not a crash.", key,
                                 (unsigned long long)g_sites[i].count);
             }
             return EXCEPTION_EXECUTE_HANDLER;   // already reported once
@@ -65,7 +65,29 @@ int guardFilter(unsigned long code, const char* site) {
     if (g_siteCount < kMaxSites) {
         g_sites[g_siteCount++] = {key, 1};
     }
-    Log::get().note("FAULT exception=0x%08lX site=%s. Further faults at this "
+    // SAY THE OUTCOME, NOT JUST THE EVENT.
+    //
+    // This line used to open with "FAULT exception=0xC0000005" and then talk
+    // only about its own bookkeeping, so the one thing a reader wants to know
+    // -- did this kill the game? -- was the one thing it did not say. Issue
+    // #13 was filed as "CTD / Access Violation" on the strength of it: the
+    // reporter pasted a run of these, every one absorbed exactly as designed,
+    // and the scan they came from succeeded four lines later in the same log.
+    // The real fault that session was a starved draw recogniser three modules
+    // away, which this line's alarm drew attention away from rather than
+    // towards.
+    //
+    // A reporter reads the first clause and stops, so the first clause is the
+    // verdict now and the bookkeeping follows it. The word FAULT is kept
+    // because logs are grepped for it and older reports quote it.
+    Log::get().note("FAULT ABSORBED exception=0x%08lX site=%s. THIS DID NOT CRASH "
+                    "THE GAME. EDVR touched an address that was not there, its own "
+                    "handler caught it, and the process carried on -- what the fault "
+                    "cost is the rest of that one operation and nothing else. A few "
+                    "of these are routine: probing memory the game is free to release "
+                    "faults by design, and the camera scan walks gigabytes of it. "
+                    "What would be worth reporting is a total below that keeps "
+                    "doubling, or a FEATURE-DISABLED line. Further faults at this "
                     "site are counted rather than logged; the running total is "
                     "restated as it doubles, so a hard exit cannot eat it.",
                     code, key);
@@ -75,7 +97,8 @@ int guardFilter(unsigned long code, const char* site) {
 void reportFaultSites() {
     for (unsigned i = 0; i < g_siteCount; ++i) {
         if (g_sites[i].count > 1) {
-            Log::get().note("FAULT TOTAL site=%s: %llu absorbed this session.",
+            Log::get().note("FAULT TOTAL site=%s: %llu absorbed this session -- "
+                            "all of them caught; none of them crashed the game.",
                             g_sites[i].site,
                             (unsigned long long)g_sites[i].count);
         }


### PR DESCRIPTION
Issue #13 was filed as "CTD / Access Violation (0xC0000005) in
camera_view/page" on the strength of these lines. Every fault in the logs
attached to it was caught by this filter and counted exactly as designed,
and the scan they came from succeeded four lines after the first one: "12
record(s) ... 1 run(s) long enough to hold ordinal 11", then "camera view
is 0 (ordinal 11, read from the game)". The failure that session was three
modules away -- an eye-draw count peaking at 16 for the whole session,
against 975 and 1074 on the two headsets here and 20 to 22 for a menu, so
the head-offset gate could never clear kSceneDraws however the player
pressed.

The line was not wrong, it was silent about the one thing a reporter wants
from it. It opened with "FAULT exception=0xC0000005 site=..." and then
spoke entirely about its own bookkeeping -- how repeats are counted, how
the total survives a hard exit -- and never said the fault had been
contained or that the process carried on. A reader stops at the first
clause, so the first clause is the verdict now: FAULT ABSORBED, THIS DID
NOT CRASH THE GAME, then what the fault actually cost, then which signal IS
worth reporting instead (a total that keeps doubling, or a FEATURE-DISABLED
line). Both total lines gain the same assurance, kept to a clause because
they repeat.

What the message claims is only what the guard guarantees. It says the
process carried on and that the cost is the rest of that one operation --
not that the frame is untouched, which for a fault part-way through a hook
body would not be true.

The word FAULT survives on purpose: logs are grepped for it and existing
reports quote it, and a token that changes meaning between versions is a
worse instrument than an alarming one.

This does not fix what #13 actually hit -- the scene-count promotion
commits before it do. It stops the next report of that failure arriving
as a crash report.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SF18H22tbutwK1K56sWz4f