### PR TITLE
transition_flash: the run cap goes to one, on five measured runs

### DIFF
--- a/docs/transition-flash.md
+++ b/docs/transition-flash.md
@@ -217,9 +217,40 @@ frame spent the detector's shot early and the real flash was shown. Some share o
 "detected and let through" reports is likely to have been that. The recognition
 rules above exist to keep those shots loaded.
 
-There is still a hard cap of two catches in a row, the burst governor above,
-and the guard that switches the whole thing off if it ever starts firing
-continuously.
+There is a hard cap on catches in a row, the burst governor above, and the
+guard that switches the whole thing off if it ever starts firing continuously.
+
+**The cap is one, and it was two until 2026-08-24.** That reversal retires the
+only number in this fix that was never chosen against a measurement.
+
+Two came from a player's description — "below the planet surface for a frame or
+two before being positioned correctly" — and a good deal of machinery was built
+to make a run of two reachable at all, because a marked frame used to discard the
+prediction so the frame after a withhold could not be judged. **That class has
+still never been captured.** Not in any session, in any log here; and the section
+below attributes that exact symptom to the external camera, where it happens
+identically with the fix switched off.
+
+What has been captured, repeatedly, is the second withhold landing on a *good*
+frame. Five runs across two field sessions:
+
+| run | frames apart | what it was |
+|---|---|---|
+| f17777→78 | 0 units | a resampled camera, sampled twice |
+| f19089→90 | 0 | the same |
+| f15610→11 | 0 | a low wake drop — **reported as a flash** |
+| f22066→67 | 10,114 | hyperspace entry — **reported as a flash** |
+| f23100→01 | 13,261 | hyperspace arrival |
+
+Every one of those held a good picture across a scene change, which is the
+artefact this fix exists to hide, manufactured by the fix. Against that, the
+two-frame class is a sentence in a bug report.
+
+The asymmetry is the whole argument. A second withhold buys nothing when the
+first frame was the entire glitch, and costs a held frame every time the jump was
+a camera *arriving* rather than a view *leaving*. One withhold is the insurance;
+two is a bet. `transition_flash_max_consecutive` keeps its full range for whoever
+captures the other class and needs it back.
 
 **Both eyes of a frame now get the same answer.** The decision is taken once, at
 whichever eye the game submits first, and the second eye follows it. Previously

--- a/edvr.ini
+++ b/edvr.ini
@@ -364,7 +364,14 @@ transition_flash_speed_factor = 8.0
 # rule's escape hatch is its zero. The log reports what every rule did, so
 # change these only against a log, not a hunch. Details:
 # docs\transition-flash.md.
-#transition_flash_max_consecutive = 2
+# How many frames in a row may be withheld. One is the insurance that a
+# bad frame is hidden; a second buys nothing when the first frame was the
+# whole glitch, and costs a good frame held over the change every time the
+# jump was a camera arriving rather than the view leaving. Shipped at 2
+# until 2026-08-24 and lowered on five measured runs, all of which spent
+# their second withhold on a good frame. Raise it only if you can capture
+# a flash that genuinely lasts two frames.
+#transition_flash_max_consecutive = 1
 #transition_flash_repeat_percent = 2.0
 #transition_flash_radius_tolerance = 0.005
 #transition_flash_park_units = 64

--- a/src/d3d11/glitch_frame.cpp
+++ b/src/d3d11/glitch_frame.cpp
@@ -1327,12 +1327,39 @@ void installGlitchFrameFix() {
     // documented as a cap on a run, so 0 reads as "no runs allowed", not as
     // "disable the feature". Anyone who wants it off has fix.transition_flash.
     //
-    // The cap is also unreachable above 1 in practice: a marked frame resets the
-    // camera history, so the next frame cannot be evaluated and a run of two
-    // never forms. The knob is kept because it bounds a future detector that
-    // could produce runs, and because removing a documented setting is worse
-    // than one that is quietly generous.
-    const int maxConsec = cfg.getInt("advanced.transition_flash_max_consecutive", 2);
+    // ONE, AND IT SHIPPED AT TWO FROM THE BEGINNING. The reversal is worth its
+    // paragraph, because it retires the only setting in this file that was
+    // never chosen against a measurement.
+    //
+    // Two came from a player's description -- "below the planet surface for a
+    // frame or two before being positioned correctly" -- and the run rules were
+    // built to make a run of two reachable, because a marked frame used to
+    // discard the prediction and the second frame of a glitch could not be
+    // judged at all. That class has still never been captured. Not once, in any
+    // session, in any log this repo has: an adversarial review went looking and
+    // found that docs/transition-flash.md attributes that exact symptom to the
+    // external camera, where it happens identically with the fix switched off.
+    //
+    // What HAS been captured, repeatedly, is the second withhold landing on a
+    // GOOD frame. Five measured runs across two field sessions:
+    //
+    //   f17777->78   0 units apart   a resampled camera, sampled twice
+    //   f19089->90   0
+    //   f15610->11   0               low wake drop, 2026-08-24, reported as a flash
+    //   f22066->67   10,114          hyperspace entry, reported as a flash
+    //   f23100->01   13,261          hyperspace arrival
+    //
+    // Every one of those held a good picture over a scene change, which is the
+    // artefact this fix exists to hide, manufactured by the fix. Against that,
+    // the two-frame class is a sentence in a bug report.
+    //
+    // So the cap goes to the value the evidence supports and the knob stays, at
+    // its full range, for whoever captures the other class and needs it back.
+    // The asymmetry is the whole argument: a second withhold buys nothing when
+    // the first frame was the whole glitch, and costs a held frame every time
+    // the jump was a camera arriving rather than a view leaving. One withhold
+    // is the insurance; two is a bet.
+    const int maxConsec = cfg.getInt("advanced.transition_flash_max_consecutive", 1);
     if (maxConsec < 1) {
         s.maxConsecutive = 1;
         Log::get().note(

--- a/tools/glitch_test/glitch_test.cpp
+++ b/tools/glitch_test/glitch_test.cpp
@@ -906,10 +906,17 @@ int main(int argc, char** argv) {
     // correctly" -- a player describing the flash that survived every fix so
     // far. One frame withheld, the second shown, and the flash remains.
     //
-    // transition_flash_max_consecutive has shipped at 2 since the beginning and
-    // has never once been reachable: a marked frame discarded the prediction, so
-    // the frame after a withhold could not be judged at all. This file's own
-    // comment on the setting said so.
+    // transition_flash_max_consecutive shipped at 2 from the beginning and was
+    // never once reachable: a marked frame discarded the prediction, so the
+    // frame after a withhold could not be judged at all. This file's own comment
+    // on the setting said so.
+    //
+    // THE DEFAULT IS 1 NOW (2026-08-24) and this fixture keeps its 2, because
+    // the suite states the value it tests rather than inheriting it. What it
+    // pins is that a run of two is REACHABLE for anyone who sets it -- the
+    // knob's whole reason for surviving. The cell below pins what the shipped
+    // default does instead, and cell Z pins that the default is what the ini
+    // says it is.
     settle(b, x, 150);
     {
         uint32_t caught = 0;
@@ -925,6 +932,32 @@ int main(int argc, char** argv) {
               "withhold is not being judged at all");
         check("...and the frame it returns on is not", !third,
               "the run ran past the excursion");
+        settle(b, x, 150);
+    }
+
+    // AND AT THE SHIPPED CAP OF ONE, the second frame is shown.
+    //
+    // This is the change of 2026-08-24, stated as behaviour rather than as a
+    // number. The same excursion the cell above withholds twice is withheld
+    // once here, and the frame after it -- which in five measured field runs
+    // was a good frame being held over a scene change -- reaches the headset.
+    settle(b, x, 150);
+    {
+        Config::get().set("advanced.transition_flash_max_consecutive", "1");
+        installGlitchFrameFix();
+        settle(b, x, 60);
+        uint32_t caught = 0;
+        x += 30.0f;
+        if (frame(b, x, 24000.0f, -11000.0f)) ++caught;
+        x += 30.0f;
+        const bool second = frame(b, x, 24500.0f, -11200.0f);
+        if (second) ++caught;
+        check("at the shipped cap of one, a two-frame excursion costs one frame",
+              caught == 1 && !second,
+              std::to_string(caught) + " withheld -- expected exactly 1, and the "
+              "second frame must reach the headset");
+        Config::get().set("advanced.transition_flash_max_consecutive", "2");
+        installGlitchFrameFix();
         settle(b, x, 150);
     }
 
@@ -1697,6 +1730,48 @@ int main(int argc, char** argv) {
                   : "the returning magnitude was not withheld, so the table "
                     "still knew it and nothing was relearned");
         settle(m, mx, 200);
+    }
+
+    // --- Z. THE SHIPPED DEFAULT, from an ini that does not state it ---------
+    //
+    // LAST, DELIBERATELY. It re-initialises Config from an ini with the key
+    // ABSENT, which is the only way to read what the code falls back to, and
+    // that would disturb anything after it -- so nothing is.
+    //
+    // It exists because a default is exactly the kind of thing that regresses
+    // in silence. The suite states max_consecutive in kIni, so every cell above
+    // would pass unchanged if the fallback were edited back to 2, or to 7. The
+    // sibling lesson is transition_flash_run_units, where renaming the key at
+    // the read site left a whole suite green.
+    {
+        static const char kDefaultIni[] =
+            "[fix]\r\n"
+            "transition_flash = 1\r\n"
+            "[advanced]\r\n"
+            "camera_buffer_bytes = 5376\r\n"
+            "camera_buffer_offset = 1100\r\n"
+            "[log]\r\n"
+            "enabled = 0\r\n";
+        const std::wstring dflt = widen(argv[1]) + L"\\defaults";
+        if (!writeIni(dflt, kDefaultIni)) {
+            check("Z: could not write the defaults ini", false, "");
+        } else {
+            Config::get().init(dflt);
+            installGlitchFrameFix();
+            Buffer d;
+            float dx = 5000.0f;
+            settle(d, dx, 400);
+            uint32_t caught = 0;
+            dx += 30.0f;
+            if (frame(d, dx, 28000.0f, -13000.0f)) ++caught;
+            dx += 30.0f;
+            const bool second = frame(d, dx, 28400.0f, -13300.0f);
+            if (second) ++caught;
+            check("Z: the shipped default caps a run at one frame",
+                  caught == 1 && !second,
+                  std::to_string(caught) + " withheld with the key absent -- the "
+                  "default is not 1; edvr.ini documents 1 and the code must agree");
+        }
     }
 
     clearGlitchFrame();


### PR DESCRIPTION
`transition_flash_max_consecutive` shipped at **2** from the beginning. It is the only number in this fix that was never chosen against a measurement, and both flashes reported from the field this week were it.

## The evidence

Two came from a player's description — *"below the planet surface for a frame or two before being positioned correctly"* — and a good deal of machinery exists to make a run of two reachable at all (a marked frame used to discard the prediction, so the frame after a withhold could not be judged). **That class has still never been captured.** Not in any session, in any log in this repo. `docs/transition-flash.md` attributes that exact symptom to the external camera, where it happens identically with `transition_flash = 0`.

What *has* been captured, repeatedly, is the second withhold landing on a **good** frame:

| run | frames apart | what it was |
|---|---|---|
| f17777→78 | 0 units | a resampled camera, sampled twice |
| f19089→90 | 0 | the same |
| **f15610→11** | **0** | a low wake drop — **reported as a flash** |
| **f22066→67** | **10,114** | hyperspace entry — **reported as a flash** |
| f23100→01 | 13,261 | hyperspace arrival |

Every one held a good picture across a scene change — the artefact this fix exists to hide, manufactured by the fix. Against that, the two-frame class is a sentence in a bug report.

A withheld frame is replaced with a copy of the last frame actually forwarded. At a wake drop or a jump that copy is the *pre-transition* picture, so holding it one frame past the cut and then snapping is exactly what a player calls a flash.

## The argument

A second withhold buys nothing when the first frame was the entire glitch, and costs a held frame every time the jump was a camera **arriving** rather than a view **leaving**. One withhold is the insurance; two is a bet.

The knob keeps its full range for whoever captures the other class and needs it back.

## What this replaces

I built the position-keyed park first and **threw it away before committing it**, because simulating it against the actual 1,200-frame ring showed it would not have worked:

- at the safe tolerance (64, the rest proof) it needs **158 entries** for one ring, and still certifies the camera **41 frames after** the frame that needed it
- at tolerances that don't thrash it certifies *drifting* cameras — steps of ~140 units certified one after another — which breaks the rest proof that stops a moving view being read as a park
- and the camera in question had **zero** sightings anywhere in the 840 ring frames before the withheld one. It does not exist until the drop, so no table, key or capacity would have known it

That also retired my "21 certified entries evicted" lead: real churn, wrong cause.

## Interaction with #16

Worth stating plainly: **at a cap of 1, the run rule in #16 never fires.** `movedOnThisFrame` requires `consecutive < maxConsecutive`, which is already false at the second frame of a run, so the run radius and the provisional-rebase machinery are inert in the shipped configuration. This branch reaches the same outcome for the hyperspace case by a much smaller route — one withhold, then the legacy resolve declares the rebase.

#16 still carries independent value (the `isfinite` guards on both thresholds, the install reset, the totals gate, `backFromPreJumpPath`, and several corrected claims), and its rule still matters for anyone who raises the cap. But its headline feature is belt-and-braces once this lands, and that is worth knowing before merging both.

This branch is off `main` and depends on nothing.

## Verification

`build.bat` green, exit 0, config contract 92/92, no new warnings at `/W4`.

Two fixtures:

- **at the shipped cap of one** — the same excursion fixture 7k withholds twice is withheld once, and the second frame reaches the headset.
- **cell Z** — pins the *default*, from an ini with the key absent. It is last in the suite because it re-initialises `Config`. It exists because `kIni` states `max_consecutive`, so every other cell would pass unchanged if the fallback were edited back to 2. **Verified failing when it is** (`2 withheld with the key absent`), while the explicit-value cell keeps passing.

Fixture 7k keeps its own `= 2` and still passes: the suite states the values it tests rather than inheriting them, and what 7k pins is that a run of two remains *reachable* for anyone who sets it.

## Not field-verified

Same caveat as #16. The symptom only exists in a headset at a real transition; the suite passing is not evidence either report is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
